### PR TITLE
add Account Created On date and override the default dynamics 365 cre…

### DIFF
--- a/ManageATenancyAPI/Actions/Housing/NHO/TenancyManagementActions.cs
+++ b/ManageATenancyAPI/Actions/Housing/NHO/TenancyManagementActions.cs
@@ -188,6 +188,13 @@ namespace ManageATenancyAPI.Actions.Housing.NHO
                 {
                     tmiJObject.Add("hackney_household_Interactionid@odata.bind", " /hackney_households(" + interaction.householdId + ")");
                 }
+
+                // householdId This is require for TM process or TM post Visit Action
+                if (interaction.AccountCreatedOn.HasValue)
+                {
+                    tmiJObject.Add("createdon", $"{interaction.AccountCreatedOn}");
+                }
+
                 try
                 {
                     _logger.LogInformation($"Create Tenancy Management Interaction");

--- a/ManageATenancyAPI/Models/Housing/NHO/TenancyManagement.cs
+++ b/ManageATenancyAPI/Models/Housing/NHO/TenancyManagement.cs
@@ -30,5 +30,6 @@ namespace ManageATenancyAPI.Models.Housing.NHO
         public string householdId { get; set; }
         public int processStage { get; set; }
         public int? reasonForStartingProcess { get; set; }
+        public DateTime? AccountCreatedOn { get; set; }
     }
 }


### PR DESCRIPTION
What:
- Override created on date with account created on date

Why:
- So that the Tenancy start date is correct.

Notes:
- Overrides the default Dynamcis 365 createdon date