### PR TITLE
Save name of signatory

### DIFF
--- a/ManageATenancyAPI/Gateways/SaveMeeting/SaveEtraMeetingSignOffMeeting/SaveEtraMeetingSignOffMeetingGateway.cs
+++ b/ManageATenancyAPI/Gateways/SaveMeeting/SaveEtraMeetingSignOffMeeting/SaveEtraMeetingSignOffMeetingGateway.cs
@@ -22,7 +22,7 @@ namespace ManageATenancyAPI.Gateways.SaveMeeting.SaveEtraMeetingSignOffMeeting
         {
             var finaliseMeetingRequest = new FinaliseETRAMeetingRequest
             {
-                //Name = signOff.Name,
+                Name = signOff.Name,
                 Role = signOff.Role,
             };
 


### PR DESCRIPTION
What:
- Re-enable saving the signatory name as the field is now in dynamics 365.